### PR TITLE
add doi for measuring beahvior

### DIFF
--- a/packages/liblsl/paper/paper.bib
+++ b/packages/liblsl/paper/paper.bib
@@ -74,7 +74,8 @@
   year = {2020},
   journal = {Measuring Behavior 2020-21 Volume},
   volume = {1},
-  pages = {26--32}
+  pages = {26--32},
+  doi = {10.6084/m9.figshare.13013717}
 }
 
 @article{iwamaTwoCommonIssues2024,


### PR DESCRIPTION
Part of: https://github.com/openjournals/joss-reviews/issues/10425

This reference doesn't have a DOI of its own, but it looks like the proceedings have a DOI for the whole collection of submissions - probably good to reference that, if just for the purposes of having a link to click where a reader could go and find the referenced work.